### PR TITLE
Add lazy_update's texts to translation

### DIFF
--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -41,7 +41,7 @@ To add an additional local:
 
 .. code-block::
 
-    pybabel extract -F babel.cfg -o messages.pot .
+    pybabel extract -F babel.cfg -k lazy_gettext -o messages.pot .
 
 
 * To get the new translations added to the .po files:


### PR DESCRIPTION
Babel use this option to add lazy_gettext() strings to .po files, otherwise translation will not to add.